### PR TITLE
fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(
-    name='Python Templet',
+    name='python_templet',
     version='4.0.0',
     description='Lightweight string templating via function decorator.',
     long_description=open('README.md', 'r').read(),
@@ -11,8 +11,7 @@ setup(
     author_email='david.bau@gmail.com',
     url='https://github.com/python-templet/templet',
     packages=[],
-    install_requires=[],
-    dependency_links=[],
+    py_modules=['templet', 'test_templet'],
     scripts=[],
     license='BSD',
     classifiers=[


### PR DESCRIPTION
You can test the packaging with

```
python setup.py sdist
```

This creates an sdist (=source) package under a newly created dist directory:

```
dist/python_templet-4.0.0.tar.gz
```

You can test the package with creating a virtualenv somewhere else

```
cd /tmp
virtualenv env
. env/bin/activate
pip install path/to/dist/python_templet-4.0.0.tar.gz
python
>>> from templet import templet
```
